### PR TITLE
Replaced deprecated resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,16 +10,12 @@ resource "azurerm_storage_account" "storage" {
   min_tls_version                 = "TLS1_2"
 }
 
-resource "azurerm_app_service_plan" "serverfarm" {
+resource "azurerm_service_plan" "serverfarm" {
   name                = var.app_service_plan_name
   resource_group_name = var.resource_group_name
   location            = var.location
-  kind                = "functionapp"
-
-  sku {
-    tier = "Dynamic"
-    size = "Y1"
-  }
+  os_type             = "Windows"
+  sku_name            = "Y1"
 }
 
 resource "azurerm_log_analytics_workspace" "workspace" {
@@ -42,7 +38,7 @@ resource "azurerm_function_app" "function" {
   name                       = var.function_app_name
   resource_group_name        = var.resource_group_name
   location                   = var.location
-  app_service_plan_id        = azurerm_app_service_plan.serverfarm.id
+  app_service_plan_id        = azurerm_service_plan.serverfarm.id
   storage_account_name       = azurerm_storage_account.storage.name
   storage_account_access_key = azurerm_storage_account.storage.primary_access_key
   version                    = "~3"

--- a/main.tf
+++ b/main.tf
@@ -34,16 +34,16 @@ resource "azurerm_application_insights" "insights" {
   workspace_id        = azurerm_log_analytics_workspace.workspace.id
 }
 
-resource "azurerm_function_app" "function" {
-  name                       = var.function_app_name
-  resource_group_name        = var.resource_group_name
-  location                   = var.location
-  app_service_plan_id        = azurerm_service_plan.serverfarm.id
-  storage_account_name       = azurerm_storage_account.storage.name
-  storage_account_access_key = azurerm_storage_account.storage.primary_access_key
-  version                    = "~3"
-  https_only                 = true
-  enable_builtin_logging     = false
+resource "azurerm_windows_function_app" "function" {
+  name                        = var.function_app_name
+  resource_group_name         = var.resource_group_name
+  location                    = var.location
+  service_plan_id             = azurerm_service_plan.serverfarm.id
+  storage_account_name        = azurerm_storage_account.storage.name
+  storage_account_access_key  = azurerm_storage_account.storage.primary_access_key
+  functions_extension_version = "~3"
+  https_only                  = true
+  builtin_logging_enabled     = false
 
   app_settings = merge({
     "APPLICATIONINSIGHTS_CONNECTION_STRING" = azurerm_application_insights.insights.connection_string
@@ -71,8 +71,8 @@ resource "azurerm_function_app" "function" {
   }
 
   site_config {
-    ftps_state      = "Disabled"
-    min_tls_version = "1.2"
+    ftps_state          = "Disabled"
+    minimum_tls_version = "1.2"
     dynamic "ip_restriction" {
       for_each = var.allowed_ip_addresses
       content {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,10 @@
 output "principal_id" {
-  value       = azurerm_function_app.function.identity[0].principal_id
+  value       = azurerm_windows_function_app.function.identity[0].principal_id
   description = "Created Managed Identity Principal ID"
 }
 
 output "tenant_id" {
-  value       = azurerm_function_app.function.identity[0].tenant_id
+  value       = azurerm_windows_function_app.function.identity[0].tenant_id
   description = "Created Managed Identity Tenant ID"
 }
 


### PR DESCRIPTION
I was deploying the terraform module and I noticed warnings about deprecated resources like this:

`The 'azurerm_app_service_plan' resource has been superseded by the 'azurerm_service_plan' resource. Whilst this resource will continue to be available in the 2.x
│ and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure
│ Provider.`

I replaced azurerm_app_service_plan with azurerm_service_plan using compatible settings. The OS wasn't specified previously but since windows was the default, I used that. I also replaced azurerm_function_app with azurerm_windows_function_app.

I deployed with my fork and the added my domain and the app worked fine.

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/azurerm_windows_function_app
