### PR TITLE
Change version to minimal 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ```hcl
 module "keyvault_acmebot" {
   source  = "shibayan/keyvault-acmebot/azurerm"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   function_app_name     = "func-acmebot-module"
   app_service_plan_name = "plan-acmebot-module"


### PR DESCRIPTION
Example in the readme.md has version 1 as minimal. Terraform init did install an 1.x version instead of 2.0.x