### PR TITLE
Include access restrictions for Advanced tool site

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,6 +120,8 @@ resource "azurerm_windows_function_app" "function" {
     application_insights_connection_string = azurerm_application_insights.insights.connection_string
     ftps_state                             = "Disabled"
     minimum_tls_version                    = "1.2"
+    scm_minimum_tls_version                = "1.2"
+    scm_use_main_ip_restriction            = true
 
     application_stack {
       dotnet_version = "v6.0"


### PR DESCRIPTION
The `azurerm_windows_function_app` resource provider defaults to `scm_use_main_ip_restriction = false`, therefore I propose including a setting to restrict the Advanced tool site to the same IP addresses as specified in the main site restrictions to preemptively curtail any possible misuse as well as explicitly restricting it to TLS 1.2 only.