### PR TITLE
Add allowed_applications field

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -35,7 +35,7 @@ data "azuread_client_config" "current" {}
 resource "azuread_application" "default" {
   display_name    = "Acmebot ${random_string.random.result}"
   identifier_uris = ["api://keyvault-acmebot-${random_string.random.result}"]
-  owners          = [data.azuread_client_config.current.object_id]
+  owners          = [data.azuread_client_config.current.application_id]
 
   api {
     requested_access_token_version = 2
@@ -85,7 +85,7 @@ resource "azuread_service_principal" "default" {
 }
 
 resource "azuread_application_password" "default" {
-  application_object_id = azuread_application.default.object_id
+  application_id = azuread_application.default.application_id
   end_date_relative     = "8640h"
 
   rotate_when_changed = {

--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,9 @@ resource "azurerm_windows_function_app" "function" {
       }
 
       active_directory_v2 {
+        allowed_applications = [
+          var.auth_settings.active_directory.client_id
+        ]
         client_id                  = var.auth_settings.active_directory.client_id
         client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
         tenant_auth_endpoint       = var.auth_settings.active_directory.tenant_auth_endpoint

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "azurerm_windows_function_app" "function" {
   }
 
   site_config {
-    application_insights_connection_string = azurerm_application_insights.insights.connection_string
+    application_insights_connection_string = var.enable_insights ? azurerm_application_insights.insights.connection_string : null
     ftps_state                             = "Disabled"
     minimum_tls_version                    = "1.2"
 
@@ -145,7 +145,8 @@ resource "azurerm_windows_function_app" "function" {
     ignore_changes = [
       tags,
       app_settings["MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"],
-      sticky_settings["app_setting_names"]
+      sticky_settings["app_setting_names"],
+      auth_settings_v2[0].active_directory_v2[0].allowed_applications,
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,10 @@ resource "azurerm_service_plan" "serverfarm" {
   }
 }
 
+
+
 resource "azurerm_log_analytics_workspace" "workspace" {
+  count               = var.enable_insights ? 1 : 0
   name                = "log-${var.app_base_name}"
   resource_group_name = var.resource_group_name
   location            = var.location
@@ -51,6 +54,7 @@ resource "azurerm_log_analytics_workspace" "workspace" {
 }
 
 resource "azurerm_application_insights" "insights" {
+  count               = var.enable_insights ? 1 : 0
   name                = "appi-${var.app_base_name}"
   resource_group_name = var.resource_group_name
   location            = var.location

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "azurerm_application_insights" "insights" {
   tags                = var.additional_tags
 
   application_type = "web"
-  workspace_id     = azurerm_log_analytics_workspace.workspace.id
+  workspace_id     = azurerm_log_analytics_workspace.workspace[0].id
 
   lifecycle {
     ignore_changes = [

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "azurerm_windows_function_app" "function" {
   }
 
   site_config {
-    application_insights_connection_string = var.enable_insights ? azurerm_application_insights.insights.connection_string : null
+    application_insights_connection_string = var.enable_insights ? azurerm_application_insights.insights[0].connection_string : null
     ftps_state                             = "Disabled"
     minimum_tls_version                    = "1.2"
 

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,11 @@ variable "time_zone" {
   default     = "UTC"
 }
 
+variable "enable_insights" {
+    description = "Enable or disable the creation of the insights"
+    default     = true
+}
+
 # Acmebot Configuration
 variable "vault_uri" {
   type        = string


### PR DESCRIPTION
* Add `allowed_applications` so it works with a registered app created independently
* Update deprecated property `object_id` with `application_id`
* Add the posibility to disable function insights