### PR TITLE
fix: added sensitive flag to the api_key output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -16,4 +16,5 @@ output "allowed_ip_addresses" {
 output "api_key" {
   value       = data.azurerm_function_app_host_keys.function.default_function_key
   description = "Created Default Functions API Key"
+  sensitive   = true
 }


### PR DESCRIPTION
Hello @shibayan ,

Terraform was throwing the below error related to the sensitive value of api_key. I have just added `sensitive   = true` in the `api_key` output.

Here is the output of the terraform



![2024-04-11_20-16-49](https://github.com/shibayan/terraform-azurerm-keyvault-acmebot/assets/6998650/9343188c-62d8-4ec5-a2e6-959d18917f22)
