### PR TITLE
Remove set `enable_https_traffic_only` property

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,6 @@ resource "azurerm_storage_account" "storage" {
   account_kind                    = "Storage"
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
-  enable_https_traffic_only       = true
   allow_nested_items_to_be_public = false
   min_tls_version                 = "TLS1_2"
 


### PR DESCRIPTION
The default value of the `enable_https_traffic_only` property is true, so the explicit specification has been removed.

Fixes #74 