### PR TITLE
Feature: Force storage name to not be longer then 24 characters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "storage" {
-  name                = "st${replace(lower(var.app_base_name), "/[^a-z0-9]/", "")}"
+  name                = "st${substr(replace(lower(var.app_base_name), "/[^a-z0-9]/", ""), 0, 22)}"
   resource_group_name = var.resource_group_name
   location            = var.location
   tags                = var.additional_tags


### PR DESCRIPTION
Hello @shibayan 

Terraform was throwing me error about storage name being too long. I could technically change the name of the app but it is upgrade from 2.1 provider version (where you name storage yourself) so I would like to keep it.
![image](https://github.com/user-attachments/assets/d11f627e-4624-4e93-ba08-d4a2619ee275)

This feature should not allow the storage name to be longer then 24 characters.