### PR TITLE
feat: update to acmebot v5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,9 +78,9 @@ resource "azurerm_windows_function_app" "function" {
   https_only                  = true
 
   app_settings = merge({
-    "FUNCTIONS_INPROC_NET8_ENABLED" = "1"
-    "WEBSITE_RUN_FROM_PACKAGE"      = "https://stacmebotprod.blob.core.windows.net/keyvault-acmebot/v4/latest.zip"
-    "WEBSITE_TIME_ZONE"             = var.time_zone
+    "WEBSITE_RUN_FROM_PACKAGE" = "https://stacmebotprod.blob.core.windows.net/keyvault-acmebot/v5/latest.zip"
+    "WEBSITE_TIME_ZONE"        = var.time_zone
+    "FUNCTIONS_WORKER_RUNTIME" = "dotnet-isolated"
   }, local.acmebot_app_settings, local.auth_app_settings, var.additional_app_settings)
 
   dynamic "sticky_settings" {
@@ -122,9 +122,10 @@ resource "azurerm_windows_function_app" "function" {
     minimum_tls_version                    = "1.2"
     scm_minimum_tls_version                = "1.2"
     scm_use_main_ip_restriction            = true
+    use_32_bit_worker                      = false
 
     application_stack {
-      dotnet_version = "v8.0"
+      dotnet_version = "v10.0"
     }
 
     ip_restriction_default_action = length(var.allowed_ip_addresses) != 0 ? "Deny" : "Allow"


### PR DESCRIPTION
Updates acmebot to v5 with .net 10 which includes the update to dotnet-isolated model.
The in-process model will be [deprecated in November 26](https://azure.microsoft.com/en-us/updates?id=retirement-support-for-the-inprocess-model-for-net-apps-in-azure-functions-ends-10-november-2026)
This probably has to be marked as a major update of the tf module.
