### PR TITLE
Update README to indicate Acmebot v4 will be archived and provide new repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [![License](https://badgen.net/github/license/shibayan/terraform-azurerm-keyvault-acmebot)](https://github.com/shibayan/terraform-azurerm-keyvault-acmebot/blob/master/LICENSE)
 [![Terraform Registry](https://badgen.net/badge/terraform/registry/5c4ee5)](https://registry.terraform.io/modules/shibayan/keyvault-acmebot/azurerm/latest)
 
+> [!IMPORTANT]
+> This module is for Acmebot v4 and will be archived because Acmebot v5 has moved to a new repository.
+> For new deployments, use [polymind-inc/terraform-azurerm-acmebot](https://github.com/polymind-inc/terraform-azurerm-acmebot) instead.
+
 ## Usage
 
 ```hcl


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the status of the repository and direct users to the new recommended module for future deployments.

Repository status update:

* Added a prominent notice indicating that this module is for Acmebot v4, will be archived, and that Acmebot v5 is now maintained in a new repository. Users are advised to use `polymind-inc/terraform-azurerm-acmebot` for new deployments.